### PR TITLE
Remove reference items from the API menu

### DIFF
--- a/site/_data/menus/api_menu.yml
+++ b/site/_data/menus/api_menu.yml
@@ -25,18 +25,12 @@
   children:
   - title: Primary Collections
     path: "/docs/reference/latest/api/reference/collections"
-  - title: Arbitration Rules
-    path: "/docs/reference/latest/api/reference/arbitration_rules"
-  - title: Arbitration Settings
-    path: "/docs/reference/latest/api/reference/arbitration_settings"
   - title: Automate Model
     path: "/docs/reference/latest/api/reference/automate"
   - title: Automate Domains
     path: "/docs/reference/latest/api/reference/automate_domains"
   - title: Automation Requests
     path: "/docs/reference/latest/api/reference/automation_requests"
-  - title: Blueprint Support
-    path: "/docs/reference/latest/api/reference/blueprints"
   - title: Categories & Tags
     path: "/docs/reference/latest/api/reference/categories_tags"
   - title: Chargebacks & Rates


### PR DESCRIPTION
Arbitration Rules and Settings, as well as Blueprint support were removed in API v3.0.0, so removing them from the doc menu as well